### PR TITLE
Update build format, switch to ARC, and add new checks  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-obj
-_
 .theos
-debs
-*.deb
+packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "framework"]
-	path = framework
-	url = git://github.com/DHowett/theos.git

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,27 @@
-IPHONE_ARCHS = armv6 armv7 arm64
+ARCHS = armv7 arm64
 
-SDKVERSION_armv6 = 5.1
-TARGET_IPHONEOS_DEPLOYMENT_VERSION = 3.0
-TARGET_IPHONEOS_DEPLOYMENT_VERSION_armv6 = 2.0
-THEOS_PLATFORM_SDK_ROOT_armv6 = /Applications/Xcode_Legacy.app/Contents/Developer
+TARGET = iphone:clang:latest:5.0
 
-include framework/makefiles/common.mk
+include $(THEOS)/makefiles/common.mk
 
 LIBRARY_NAME = libprefs
 libprefs_LOGOSFLAGS = -c generator=internal
 libprefs_FILES = prefs.xm
-libprefs_FRAMEWORKS = UIKit
+libprefs_FRAMEWORKS = Foundation
 libprefs_PRIVATE_FRAMEWORKS = Preferences
-libprefs_CFLAGS = -I.
+libprefs_CFLAGS = -fobjc-arc -I.
 libprefs_COMPATIBILITY_VERSION = 2.2.0
 libprefs_LIBRARY_VERSION = $(shell echo "$(THEOS_PACKAGE_BASE_VERSION)" | cut -d'~' -f1)
 libprefs_LDFLAGS  = -compatibility_version $($(THEOS_CURRENT_INSTANCE)_COMPATIBILITY_VERSION)
 libprefs_LDFLAGS += -current_version $($(THEOS_CURRENT_INSTANCE)_LIBRARY_VERSION)
-libprefs_IPHONE_ARCHS = armv6 armv7 armv7s arm64
+libprefs_ARCHS = armv7 armv7s arm64
 
 TWEAK_NAME = PreferenceLoader
 PreferenceLoader_FILES = Tweak.xm
-PreferenceLoader_FRAMEWORKS = UIKit
+PreferenceLoader_FRAMEWORKS = Foundation
 PreferenceLoader_PRIVATE_FRAMEWORKS = Preferences
 PreferenceLoader_LIBRARIES = prefs
-PreferenceLoader_CFLAGS = -I.
+PreferenceLoader_CFLAGS = -fobjc-arc -I.
 PreferenceLoader_LDFLAGS = -L$(THEOS_OBJ_DIR)
 
 include $(THEOS_MAKE_PATH)/library.mk
@@ -35,7 +32,6 @@ after-libprefs-stage::
 	$(ECHO_NOTHING)cp prefs.h $(THEOS_STAGING_DIR)/usr/include/libprefs/prefs.h$(ECHO_END)
 
 after-stage::
-	find $(THEOS_STAGING_DIR) -iname '*.plist' -exec plutil -convert binary1 {} \;
 	$(FAKEROOT) chown -R 0:80 $(THEOS_STAGING_DIR)
 	mkdir -p $(THEOS_STAGING_DIR)/Library/PreferenceBundles $(THEOS_STAGING_DIR)/Library/PreferenceLoader/Preferences
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARCHS = armv7 arm64
-
 TARGET = iphone:clang:latest:5.0
+INSTALL_TARGET_PROCESSES = Preferences
 
 include $(THEOS)/makefiles/common.mk
 
@@ -34,6 +34,3 @@ after-libprefs-stage::
 after-stage::
 	$(FAKEROOT) chown -R 0:80 $(THEOS_STAGING_DIR)
 	mkdir -p $(THEOS_STAGING_DIR)/Library/PreferenceBundles $(THEOS_STAGING_DIR)/Library/PreferenceLoader/Preferences
-
-after-install::
-	install.exec "killall -9 Preferences"

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -57,6 +57,10 @@ static NSInteger PSSpecifierSort(PSSpecifier *a1, PSSpecifier *a2, void *context
 			if(![[item pathExtension] isEqualToString:@"plist"]) continue;
 			PLLog(@"processing %@", item);
 			NSString *fullPath = [NSString stringWithFormat:@"/Library/PreferenceLoader/Preferences/%@", item];
+			if(![[NSFileManager defaultManager] isReadableFileAtPath:fullPath]) {
+				PLLog(@"%@ is NOT readable!", item);
+				continue;
+			}
 			NSDictionary *plPlist = [NSDictionary dictionaryWithContentsOfFile:fullPath];
 			if(![PSSpecifier environmentPassesPreferenceLoaderFilter:[plPlist objectForKey:@"filter"] ?: [plPlist objectForKey:PLFilterKey]]) continue;
 

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: preferenceloader
 Name: PreferenceLoader
-Depends: mobilesubstrate
-Version: 2.2.4~alpha1
+Depends: mobilesubstrate, firmware (>= 5.0)
+Version: 2.3.0
 Architecture: iphoneos-arm
 Description: load preferences in style
 Maintainer: Dustin Howett <cydia.pl@relay.howett.net>

--- a/prefs.h
+++ b/prefs.h
@@ -16,3 +16,6 @@ extern NSString *const PLFilterKey;
 
 @interface PLLocalizedListController: PLCustomListController { }
 @end
+
+@interface PLFailedBundleListController: PSListController { }
+@end

--- a/prefs.xm
+++ b/prefs.xm
@@ -285,17 +285,17 @@ static void pl_lazyLoadBundleCore(id self, SEL _cmd, PSSpecifier *specifier, voi
 		return nil;
 
 	PLLog(@"Loading specifiers from PSListController's specifier's properties.");
-	NSMutableArray __strong *&bundleControllers = MSHookIvar<NSMutableArray *>(self, "_bundleControllers");
-	NSString *title = nil;
-	NSString *specifierID = nil;
-	result = SpecifiersFromPlist(properties, [self specifier], target, plistName, [self bundle], &title, &specifierID, self, &bundleControllers);
-
 	NSString *file = [[self bundle] pathForResource:plistName ofType:@"plist"];
 	if(![[NSFileManager defaultManager] isReadableFileAtPath:file]) {
 		PLLog(@"%@ is NOT readable!", file);
 		[self setTitle:[NSString stringWithFormat:@"%@.plist is unreadable", plistName]];
 		return nil;
 	}
+
+	NSMutableArray __strong *&bundleControllers = MSHookIvar<NSMutableArray *>(self, "_bundleControllers");
+	NSString *title = nil;
+	NSString *specifierID = nil;
+	result = SpecifiersFromPlist(properties, [self specifier], target, plistName, [self bundle], &title, &specifierID, self, &bundleControllers);
 
 	if([result count] < 1) {
 		PLLog(@"%@ likely has a format error!", file);

--- a/prefs.xm
+++ b/prefs.xm
@@ -290,6 +290,19 @@ static void pl_lazyLoadBundleCore(id self, SEL _cmd, PSSpecifier *specifier, voi
 	NSString *specifierID = nil;
 	result = SpecifiersFromPlist(properties, [self specifier], target, plistName, [self bundle], &title, &specifierID, self, &bundleControllers);
 
+	NSString *file = [[self bundle] pathForResource:plistName ofType:@"plist"];
+	if(![[NSFileManager defaultManager] isReadableFileAtPath:file]) {
+		PLLog(@"%@ is NOT readable!", file);
+		[self setTitle:[NSString stringWithFormat:@"%@.plist is unreadable", plistName]];
+		return nil;
+	}
+
+	if([result count] < 1) {
+		PLLog(@"%@ likely has a format error!", file);
+		[self setTitle:[NSString stringWithFormat:@"%@.plist format error", plistName]];
+		return nil;
+	}
+
 	if(title)
 		[self setTitle:title];
 
@@ -346,6 +359,11 @@ static void pl_lazyLoadBundleCore(id self, SEL _cmd, PSSpecifier *specifier, voi
 	} else {
 		prefBundle = [NSBundle bundleWithPath:sourceBundlePath];
 		PLLog(@"is NOT a bundle, so we're giving it %@!", prefBundle);
+	}
+
+	if(![[NSFileManager defaultManager] isReadableFileAtPath:bundlePath]) {
+		PLLog(@"%@ is NOT readable!", bundlePath);
+		return nil;
 	}
 
 	PLLog(@"loading specifiers!");


### PR DESCRIPTION
Changes
---
- Updated to build with the latest Theos 
- Updated the build target to iOS 5 in order to enable ARC 
- Added new checks for
  - Unreadable bundles 
  - Unreadable plists
  - Ill-formatted plists

Notes
---
- I am not particularly familiar with this codebase, so I apologize in advance if any of the checks are out of place 
- Tested on iP7 iOS 14.3 built on Linux (WSL) with https://github.com/theos/theos/commit/782255f2939842818fa65ac60fab402f5e6c009d 